### PR TITLE
Fix merge order for the "all groups" usecase

### DIFF
--- a/pkg/groups/groups.go
+++ b/pkg/groups/groups.go
@@ -21,14 +21,15 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 )
 
 /*
-Groups returns a list of available group in the given directory
+Groups returns an unsorted list of available group in the given directory
 limited by the provided filter. Each element of the list given
-in filter will be treated as a regex and only group matching
+in filter will be treated as a regex and only groups matching
 any (!) of the filters will be returned. The regexp will be treated
-as matching the whole group name, e.h. they are implicitely wrapped
+as matching the whole group name, e.g. they are implicitely wrapped
 in ^$
 */
 func Groups(directory string, filter string, limits []string) ([]string, error) {
@@ -95,6 +96,18 @@ func Groups(directory string, filter string, limits []string) ([]string, error) 
 		result = groups
 	}
 	return result, nil
+}
+
+/*
+SortedGroups is the same as Groups() but the resulting list is sorted alphabetically
+*/
+func SortedGroups(directory string, filter string, limits []string) ([]string, error) {
+	g, err := Groups(directory, filter, limits)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(g)
+	return g, nil
 }
 
 // LimitGroups applies a list of limits (each treated as regex) to a list

--- a/pkg/groups/groups_test.go
+++ b/pkg/groups/groups_test.go
@@ -40,10 +40,9 @@ func TestGroups(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotGroups, err := Groups("testdata", tc.filter, tc.limits)
+			gotGroups, err := SortedGroups("testdata", tc.filter, tc.limits)
 			assert.NilError(t, err)
 			wantGroups := tc.expected
-			sort.Strings(gotGroups)
 			sort.Strings(wantGroups)
 			assert.DeepEqual(t, wantGroups, gotGroups)
 		})

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -46,7 +46,7 @@ func New(path string, groups []string, skipEval bool, ejsonSettings ejson.Settin
 		// get a list of all groups in the given directory
 		dirGroups := groups
 		if len(dirGroups) <= 0 {
-			dirGroups, err = groupsfilter.Groups(path, ".*", []string{})
+			dirGroups, err = groupsfilter.SortedGroups(path, ".*", []string{})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -48,9 +48,8 @@ func TestValues(t *testing.T) {
 	}{
 		"file":           {input: "file/spruce-eval.yml", skipEval: false, expected: "file/spruce-eval.expected.yml"},
 		"file-skip-eval": {input: "file/spruce-eval.yml", skipEval: true, expected: "file/spruce-eval.yml"},
-		// TODO: possible race condition? Execute multiple times uncached
-		"dir":           {input: "file", skipEval: false, expected: "file/spruce-eval.expected.yml"},
-		"dir-skip-eval": {input: "file", skipEval: true, expected: "file/spruce-eval.yml"},
+		"dir":            {input: "file", skipEval: false, expected: "file/spruce-eval.expected.yml"},
+		"dir-skip-eval":  {input: "file", skipEval: true, expected: "file/spruce-eval.yml"},
 	}
 
 	ejsonSettings := ejson.Settings{


### PR DESCRIPTION
Add a SortedGroups() function and ensure this is used instead of
Groups() in cases where the list is passed to the values package
as Groups() returns an unsorted list and all values functions
expect a sorted list to determine merge order.