### PR TITLE
chore: Release Kusible as Docker Images

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,35 @@
+#
+# Copyright © 2021 Bedag Informatik AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#  This is a basic workflow to help you get started with Actions
+#
+name: docker-test
+on:
+  pull_request:
+jobs:
+  build-test:
+    if: ${{ github.event.issue.pull_request }} && ! contains(github.event.head_commit.message, 'ci skip')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: image-build-action
+        uses: bedag/image-build-action@main
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: bedag/kusible
+          format: 'table'
+          output: 'trivy'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,15 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: image-build-action
+        uses: bedag/image-build-action@main
+        with:
+          push: true
+          docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker_password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -1,0 +1,35 @@
+#
+# Copyright © 2021 Bedag Informatik AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+## Build Kusible
+FROM golang AS build
+WORKDIR /build
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kusible . \ 
+  && chmod +x ./kusible
+
+## Kusible Container
+FROM {{ _source["name"] }} 
+
+LABEL  \{% for tag in _dest['tags']|list %}
+  "tag.{{ tag }}.repository"="{{ _dest['namespace'] }}/{{ _dest['name'] }}" \
+  "tag.{{ tag }}.source"="{{ _source["name"] }}:{{ _source["tag"] }}" \
+  "tag.{{ tag }}.git.repo"="{{ git_repo }}" \
+  "tag.{{ tag }}.git.ref"="{{ git_ref }}" \
+  "tag.{{ tag }}.git.commit"="{{ git_commit }}" \
+{%- endfor %}
+  "maintainer"="{{ maintainer }}" 
+
+COPY --from=build /build/kusible /
+ENTRYPOINT [ "/kusible" ]

--- a/image-build.yml
+++ b/image-build.yml
@@ -1,0 +1,46 @@
+---
+#
+# Copyright © 2021 Bedag Informatik AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## Globals 
+global: &global
+  namespace: "bedag"
+  name: kusible
+  variables:
+    maintainer: "noc@bedag.ch"
+
+## Scratch Base 
+scratch_base: &scratch_base
+  source:
+    name: scratch
+
+## Alpine Base 
+alpine_base: &alpine_base
+  source:
+    name: alpine
+
+# Builds
+builds:
+  - <<: *global
+    <<: *scratch_base
+    tags:
+    - template: "{{ git_tag }}"
+    - template: "latest"
+  - <<: *global
+    <<: *alpine_base
+    tags:
+    - template: "{{ git_tag }}-alpine"
+    - template: "latest-alpine"

--- a/pkg/wrapper/helm/install.go
+++ b/pkg/wrapper/helm/install.go
@@ -92,9 +92,6 @@ func (h *Helm) runInstall(args []string, vals map[string]interface{}, client *ac
 	}
 
 	if req := chartRequested.Metadata.Dependencies; req != nil {
-		// If CheckDependencies returns an error, we have unfulfilled dependencies.
-		// As of Helm 2.4.0, this is treated as a stopping condition:
-		// https://github.com/helm/helm/issues/2209
 		if err := action.CheckDependencies(chartRequested, req); err != nil {
 			if client.DependencyUpdate {
 				man := &downloader.Manager{


### PR DESCRIPTION
Add Github workflow that publishes kusible on tag on Dockerhub. Currently two images are published: One based on Scratch and one based on Alpine.